### PR TITLE
Remove pmartR from remotes in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,6 @@ Imports:
 Remotes:
     github::hafen/trelliscopejs,
     github::dengkuistat/WaveICA_2.0,
-    github::pmartR/pmartR,
     github::pmartR/pmartRdata
 Suggests:
     rmarkdown,


### PR DESCRIPTION
Removed pmartR from the list of remotes since it is now on CRAN.